### PR TITLE
tweaking image conversion to use other more robust methods

### DIFF
--- a/src/processing/embroider/PEmbroiderGraphics.java
+++ b/src/processing/embroider/PEmbroiderGraphics.java
@@ -1777,33 +1777,6 @@ public class PEmbroiderGraphics {
 
 	/* SHAPE INTERFACE */
 	
-	public ArrayList<ArrayList<PVector>> hatchImg(ArrayList<PVector> poly) {
-		ArrayList<ArrayList<PVector>> polys = new ArrayList<ArrayList<PVector>>();
-		if (HATCH_MODE == PARALLEL) {
-			polys = hatchParallel(poly,HATCH_ANGLE,HATCH_SPACING);
-		}else if (HATCH_MODE == CROSS) {
-			polys = hatchParallel(poly,HATCH_ANGLE, HATCH_SPACING);
-			polys.addAll(hatchParallel(poly,HATCH_ANGLE2,HATCH_SPACING));
-		}else if (HATCH_MODE == CONCENTRIC) {
-			polys = hatchInset(poly,HATCH_SPACING,9999);
-			for (int i = 0; i < polys.size(); i++) {
-				polys.get(i).add(polys.get(i).get(0));
-			}
-		}else if (HATCH_MODE == SPIRAL) {
-			polys = hatchSpiral(poly,HATCH_SPACING,9999);
-		}else if (HATCH_MODE == PERLIN) {
-			polys = hatchPerlin(poly,HATCH_SPACING,STITCH_LENGTH,HATCH_SCALE,9999);
-		}else if (HATCH_MODE == VECFIELD) {
-			polys = hatchCustomField(poly,HATCH_VECFIELD,HATCH_SPACING,STITCH_LENGTH,9999);
-		}else if (HATCH_MODE == DRUNK) {
-			polys = hatchDrunkWalk(poly,10,999);
-		}
-		for (int i = 0; i < polys.size(); i++) {
-			pushPolyline(polys.get(i),currentFill,1f);
-		}
-		return polys;
-	}
-
 	public void hatch(ArrayList<PVector> poly) {
 		ArrayList<ArrayList<PVector>> polys = new ArrayList<ArrayList<PVector>>();
 		if (HATCH_MODE == PARALLEL) {

--- a/src/processing/embroider/PEmbroiderGraphics.java
+++ b/src/processing/embroider/PEmbroiderGraphics.java
@@ -1776,6 +1776,33 @@ public class PEmbroiderGraphics {
 	}
 
 	/* SHAPE INTERFACE */
+	
+	public ArrayList<ArrayList<PVector>> hatchImg(ArrayList<PVector> poly) {
+		ArrayList<ArrayList<PVector>> polys = new ArrayList<ArrayList<PVector>>();
+		if (HATCH_MODE == PARALLEL) {
+			polys = hatchParallel(poly,HATCH_ANGLE,HATCH_SPACING);
+		}else if (HATCH_MODE == CROSS) {
+			polys = hatchParallel(poly,HATCH_ANGLE, HATCH_SPACING);
+			polys.addAll(hatchParallel(poly,HATCH_ANGLE2,HATCH_SPACING));
+		}else if (HATCH_MODE == CONCENTRIC) {
+			polys = hatchInset(poly,HATCH_SPACING,9999);
+			for (int i = 0; i < polys.size(); i++) {
+				polys.get(i).add(polys.get(i).get(0));
+			}
+		}else if (HATCH_MODE == SPIRAL) {
+			polys = hatchSpiral(poly,HATCH_SPACING,9999);
+		}else if (HATCH_MODE == PERLIN) {
+			polys = hatchPerlin(poly,HATCH_SPACING,STITCH_LENGTH,HATCH_SCALE,9999);
+		}else if (HATCH_MODE == VECFIELD) {
+			polys = hatchCustomField(poly,HATCH_VECFIELD,HATCH_SPACING,STITCH_LENGTH,9999);
+		}else if (HATCH_MODE == DRUNK) {
+			polys = hatchDrunkWalk(poly,10,999);
+		}
+		for (int i = 0; i < polys.size(); i++) {
+			pushPolyline(polys.get(i),currentFill,1f);
+		}
+		return polys;
+	}
 
 	public void hatch(ArrayList<PVector> poly) {
 		ArrayList<ArrayList<PVector>> polys = new ArrayList<ArrayList<PVector>>();
@@ -2405,7 +2432,8 @@ public class PEmbroiderGraphics {
 		im2.image(im,0,0,w,h);
 		im2.filter(PConstants.INVERT);
 		im2.filter(PConstants.THRESHOLD);
-
+	
+		
 		ArrayList<ArrayList<PVector>> polys = PEmbroiderTrace.findContours(im2);
 
 		for (int i = polys.size()-1; i >= 0; i--) {
@@ -2418,26 +2446,16 @@ public class PEmbroiderGraphics {
 			polys.set(i, PEmbroiderTrace.approxPolyDP(polys.get(i),1));
 
 		}
-		ArrayList<ArrayList<PVector>> hatches = new ArrayList<ArrayList<PVector>>();
-		for (int i = 0; i < polys.size(); i++) {
-			hatches.addAll(hatchParallel(polys.get(i),HATCH_ANGLE,HATCH_SPACING));
-			//			hatches.addAll(hatchInset(polys.get(i),HATCH_SPACING,99));
-			//			hatches.addAll(hatchSpiral(polys.get(i),HATCH_SPACING,99));
-		}
+
+	
 		if (isStroke && FIRST_STROKE_THEN_FILL) {
-			for (int i = 0; i < polys.size(); i++) {
-				pushPolyline(polys.get(i),currentStroke,0f);
-			}
+			_stroke(polys, true);
 		}
 		if (isFill) {
-			for (int i = 0; i < hatches.size(); i++) {
-				pushPolyline(hatches.get(i),currentFill,1f);
-			}
+			hatchRaster(im2);
 		}
 		if (isStroke && !FIRST_STROKE_THEN_FILL) {
-			for (int i = 0; i < polys.size(); i++) {
-				pushPolyline(polys.get(i),currentStroke,0f);
-			}
+			_stroke(polys, true);
 		}
 	}
 


### PR DESCRIPTION
I was playing around with the library and saw an issue with Image Conversion. 

File
![Screen Shot 2020-06-09 at 8 47 16 AM](https://user-images.githubusercontent.com/719564/84162320-3d381000-aa3e-11ea-9a4d-ab2d4cf8da51.png)

Output
![Screen Shot 2020-06-09 at 8 47 18 AM](https://user-images.githubusercontent.com/719564/84162305-3ad5b600-aa3e-11ea-80de-0b7c9626f796.png)

I made some to make the internal of image use _stroke and hatchRaster rather than hard-coded to hatchParallel. Now the image conversion takes into account hatch modes and correctly hatches the images. 

output after the corrections  
![Screen Shot 2020-06-09 at 10 41 27 AM](https://user-images.githubusercontent.com/719564/84162615-9607a880-aa3e-11ea-94ed-dd2d0a8768b3.png)

![Screen Shot 2020-06-09 at 10 41 57 AM](https://user-images.githubusercontent.com/719564/84162619-97d16c00-aa3e-11ea-8a1b-a32777adec9d.png)

![Screen Shot 2020-06-09 at 10 49 29 AM](https://user-images.githubusercontent.com/719564/84162929-ef6fd780-aa3e-11ea-9a38-2b4270f490fc.png)

![Screen Shot 2020-06-09 at 10 48 13 AM](https://user-images.githubusercontent.com/719564/84162952-f4cd2200-aa3e-11ea-95f4-1e4a6e26bf6f.png)

